### PR TITLE
Adding Digest authentication method.

### DIFF
--- a/PSSonicWall/Private/get-digest.ps1
+++ b/PSSonicWall/Private/get-digest.ps1
@@ -1,0 +1,88 @@
+#requires -version 6
+
+# provide data object to post back to sonicwall
+function Get-SWdigest {
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$device,
+        [Parameter(Mandatory = $true, Position = 1)]
+        [pscredential]$credentials
+    )
+    
+    # Query the sonicwall for the digest info
+    $chap_info = get-SWdigestdata -device $device
+
+    # calculate the digest hash
+    $hash = new-SWdigesthash -id $chap_info.id -Credential $credentials -challange $chap_info.challenge -algorithm MD5
+
+    
+    # Data to be posted to the API endpoint (in json format)
+    return [ordered]@{
+        "id" = $chap_info.id
+        "user" = "admin"
+        "digest" = $hash
+    } | ConvertTo-Json
+}
+
+# Get ID and challange (Digest info)
+function get-SWdigestdata {
+    param(
+        [Parameter(Mandatory=$true,Position=0)]$device
+    )
+    try {
+        $params = @{
+            SkipCertificateCheck    = $true
+            Method                  = "GET"
+            Uri                     = "https://$device/api/sonicos/auth"
+            Headers                 = @{
+                                        accept  = "application/json"
+                                        }
+        }
+        Invoke-RestMethod @params
+    
+    } catch {
+        return $_.ErrorDetails.Message | ConvertFrom-Json
+    }
+}
+
+# calculate hash
+function new-SWdigesthash {
+    param(
+        [Parameter(Mandatory = $true)]$id,
+        [Parameter(Mandatory = $true)][pscredential]$Credential,
+        [Parameter(Mandatory = $true)]$challange,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("MD5", "SHA", "SHA1", "SHA-256", "SHA-384", "SHA-512")]
+        [String]$algorithm
+    )
+    # convert Chap ID from hex to a bytes array
+    [array]$id   = convertfrom-hex -data $id
+    
+    # convert password to plain text and to a byte array 
+    $plaintext = $($Credential.GetNetworkCredential().Password)
+    [array]$pass = [byte[]][char[]]"$plaintext"
+    Remove-Variable plaintext
+
+    # Convert Chap challange from hex to a byte array
+    [array]$chal = convertfrom-hex -data $challange
+
+    # combine all needed puzzle pieces into one big array
+    [array]$comb = $id + $pass + $chal
+
+    # create a algorithm object
+    $hashalgorithm = [System.Security.Cryptography.HashAlgorithm]::Create($algorithm)
+
+    # output the hash calculation
+    return $hashalgorithm.ComputeHash($comb).ForEach({$_.ToString("x2")})-join ""
+}
+
+# Convert hex to byte array
+function convertfrom-hex {
+    param (
+        [string]$data
+    )
+    $hex_array = for ([int32]$i = 0 ; $i -lt $data.Length; $i += 2 ) {
+        $data.Substring($i,2)
+    }
+    $hex_array.foreach({[byte]"0x$_"})
+}


### PR DESCRIPTION
The following PR request will add the ability to authenticate using chap authentication versus using basic authentication. The benefit of chap is that it does not require to send over the password to the device.

I have tested the new changes on my computer and it worked.

Breaking changes: Because I'm using newer parameters of invoke-rest method Powershell v6 is required.

Note: Requires to enable the CHAP authentication by the API settings.

I also created a pull request at the source repo, but that seems to have no activity for a longer time then yours, so I'm also opening it with you. If you want we can collaborate and try to build out this module even more.